### PR TITLE
Fix memory issues (fanalyzer, asan)

### DIFF
--- a/cano_sh.h
+++ b/cano_sh.h
@@ -68,7 +68,6 @@ char *str_to_cstr(String str);
 int shell_repl_run(void);
 
 char **parse_command(char *command);
-void execute_command(char **args);
 void handle_command(char **args);
 
 bool shell_repl_initialize(Repl *repl);

--- a/main.c
+++ b/main.c
@@ -84,6 +84,7 @@ char *str_to_cstr(String str) {
 }
 	
 char **parse_command(char *command) {
+	char const *marker = &command[strlen(command) + 1];
 	char *cur = strtok(command, " ");
 	if(cur == NULL) {
 		return NULL;
@@ -102,7 +103,7 @@ char **parse_command(char *command) {
 		while(command[0] != '\0') command++;
 		command++;
 		assert(command);
-		if(command[0] == '\'') {
+		if(marker < command && command[0] == '\'') {
 			command++;
 			args[args_cur++] = cur;
 			cur = command;

--- a/main.c
+++ b/main.c
@@ -17,6 +17,7 @@
 #define ctrl(x) ((x) & 0x1f)
 #define SHELL "[canosh]$ "
 
+static __attribute__((nonnull))
 void execute_command(char **args) {
 	int status;
 	int pid = fork();
@@ -37,6 +38,7 @@ void execute_command(char **args) {
 	}	
 }
 	
+__attribute__((nonnull))
 void handle_command(char **args) {
 	if(*args == NULL) {
 		fprintf(stderr, "error, no command\n");
@@ -82,7 +84,7 @@ char *str_to_cstr(String str) {
 	cstr[str.count] = '\0';
 	return cstr;
 }
-	
+
 char **parse_command(char *command) {
 	char const *marker = &command[strlen(command) + 1];
 	char *cur = strtok(command, " ");
@@ -95,10 +97,16 @@ char **parse_command(char *command) {
         return NULL;
     }
 	size_t args_cur = 0;
-	while(cur != NULL) {	
+	char **resized;
+	while(cur != NULL) {
 		if(args_cur+2 >= args_s) {
 			args_s *= 2;
-			args = realloc(args, sizeof(char*)*args_s);
+			resized = realloc(args, sizeof(char*)*args_s);
+			if (resized == NULL) {
+				free(args);
+				return false;
+			}
+			args = resized;
 		}
 		while(command[0] != '\0') command++;
 		command++;

--- a/repl.c
+++ b/repl.c
@@ -41,8 +41,15 @@ bool export shell_readline(Repl *repl)
 
 bool export shell_evaluate(Repl *repl)
 {
-	char **args = parse_command(repl->input);
+	bool has_cmd = false;
+	char **args;
 
+	for (char *p = repl->input; !has_cmd && *p != '\0'; p++)
+		has_cmd |= !isspace(*p);
+    if (strlen(repl->input) < 1 || !has_cmd)
+		return true;
+
+	args = parse_command(repl->input);
 	if (args == NULL)
 		return false;
 	handle_command(args);

--- a/repl.c
+++ b/repl.c
@@ -21,11 +21,13 @@ bool export shell_repl_initialize(Repl *repl) {
 
 void export shell_cleanup(Repl *repl)
 {
-	(void)repl;
+	free(repl->input);
 }
 
 bool export shell_readline(Repl *repl)
 {
+	if (repl->input != NULL)
+		free(repl->input);
 	repl->input = readline(SHELL_PROMPT);
 	// sending `^D` will cause readline to return NULL 
 	if (repl->input == NULL) {
@@ -41,11 +43,11 @@ bool export shell_evaluate(Repl *repl)
 {
 	char **args = parse_command(repl->input);
 
-	if (args != NULL) {
-		handle_command(args);
-		//DA_APPEND(&repl->command_his, repl->input);
-	}
-	free(repl->input);
+	if (args == NULL)
+		return false;
+	handle_command(args);
+	//DA_APPEND(&repl->command_his, repl->input);
+	free(args);
 	return true;
 }
 


### PR DESCRIPTION
> [!CAUTION]
> Commit from the previous pr needs to be cherry picked, once the previous pr is merged (ping me on discord)
> - stacked from: #16 

- Handle argument allocation errors
  - Skip command execution for space-only strings (added to avoid `parse_command` returning `args` with `NULL`)

- Fixes
  - Buffer overflow in command quotes parsing
  - Free the memory we allocate
  - Mark `args` as `nonnull` in sub-functions (fanalyzer)

